### PR TITLE
Add module-info when compiling with JDK 9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ jdk:
 addons:
   apt:
     packages:
-      - oraclejdk8 // to recompile for java 5
       - graphviz
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: java
 jdk:
-- oraclejdk8
+- oraclejdk9
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,16 @@ dist: trusty
 
 language: java
 jdk:
-- oraclejdk9
+  - oraclejdk9
 
 addons:
   apt:
     packages:
+      - oracle-java8-installer # to recompile for java 5
       - graphviz
 cache:
   directories:
-  - $HOME/.m2/repository
+    - $HOME/.m2/repository
 
 before_install:
   # copy maven settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jdk:
 addons:
   apt:
     packages:
+      - oraclejdk8 // to recompile for java 5
       - graphviz
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <jdkToolchain>
+                                <version>9</version>
+                            </jdkToolchain>
+                            <source>9</source>
+                            <target>9</target>
+                            <release>9</release>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <encoding>${project.build.sourceEncoding}</encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.5</maven.compiler.source>
-        <maven.compiler.target>1.5</maven.compiler.target>
+        <maven.compiler.source>9</maven.compiler.source>
+        <maven.compiler.target>9</maven.compiler.target>
 
         <!-- runtime -->
 
@@ -86,7 +86,7 @@
         <!-- build -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
         <maven-failsafe-plugin.version>2.20.1</maven-failsafe-plugin.version>
         <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
@@ -239,6 +239,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
+                            <javadocVersion>1.8</javadocVersion>
                             <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
                             <docletArtifact>
                                 <groupId>nl.talsmasoftware</groupId>
@@ -253,6 +254,9 @@
                                 -umlCommand "hide empty fields"
                                 -umlCommand "hide empty methods"
                             </additionalparam>
+                            <sourceFileExcludes>
+                                <sourceFileExclude>module-info.java</sourceFileExclude>
+                            </sourceFileExcludes>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,13 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>${coveralls-maven-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.2.3</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+<!--
         <maven.compiler.source>9</maven.compiler.source>
         <maven.compiler.target>9</maven.compiler.target>
+-->
 
         <!-- runtime -->
 
@@ -175,28 +177,51 @@
                     </dependency>
                 </dependencies>
             </plugin>
+
+            <!--
+                Taken from example on
+                https://maven.apache.org/plugins/maven-compiler-plugin/examples/module-info.html
+             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>default-compile</id>
                         <configuration>
+                            <!-- compile everything to ensure module-info contains right entries -->
+                            <!-- required when JAVA_HOME is JDK 8 or below -->
                             <jdkToolchain>
                                 <version>9</version>
                             </jdkToolchain>
-                            <source>9</source>
-                            <target>9</target>
                             <release>9</release>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <!-- recompile everything for target VM except the module-info.java -->
+                        <configuration>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
                 </executions>
+                <!-- defaults for compile and testCompile -->
                 <configuration>
-                    <showDeprecation>true</showDeprecation>
-                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <!-- jdkToolchain required when JAVA_HOME is JDK 9 or above -->
+                    <jdkToolchain>
+                        <version>[1.5,9)</version>
+                    </jdkToolchain>
+                    <source>1.5</source>
+                    <target>1.5</target>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-
-            <!--
-                Taken from example on
-                https://maven.apache.org/plugins/maven-compiler-plugin/examples/module-info.html
-             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -190,8 +185,6 @@
                     <execution>
                         <id>default-compile</id>
                         <configuration>
-                            <!-- compile everything to ensure module-info contains right entries -->
-                            <!-- required when JAVA_HOME is JDK 8 or below -->
                             <jdkToolchain>
                                 <version>9</version>
                             </jdkToolchain>
@@ -203,7 +196,6 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
-                        <!-- recompile everything for target VM except the module-info.java -->
                         <configuration>
                             <excludes>
                                 <exclude>module-info.java</exclude>
@@ -211,9 +203,7 @@
                         </configuration>
                     </execution>
                 </executions>
-                <!-- defaults for compile and testCompile -->
-                <configuration>
-                    <!-- jdkToolchain required when JAVA_HOME is JDK 9 or above -->
+                <configuration> <!-- defaults for compile and testCompile -->
                     <jdkToolchain>
                         <version>[1.5,9)</version>
                     </jdkToolchain>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2017 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module talsmasoftware.reflection {
+
+    exports nl.talsmasoftware.reflection;
+    exports nl.talsmasoftware.reflection.beans;
+    exports nl.talsmasoftware.reflection.dto;
+    exports nl.talsmasoftware.reflection.errorhandling;
+    exports nl.talsmasoftware.reflection.strings;
+
+    requires java.desktop;
+    requires java.logging;
+
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -21,7 +21,7 @@ module talsmasoftware.reflection {
     exports nl.talsmasoftware.reflection.errorhandling;
     exports nl.talsmasoftware.reflection.strings;
 
-    requires java.desktop;
+    requires java.desktop; // TODO implement ourselves.
     requires java.logging;
 
 }


### PR DESCRIPTION
Next step: Tell maven to re-compile all classes (excl. module-info)
with source/target level 1.5

When this PR is done, this fixes #1.