### PR TITLE
ToStringBuilder: Replace extremely long values with type name

### DIFF
--- a/src/test/java/nl/talsmasoftware/reflection/dto/AbstractDtoTest.java
+++ b/src/test/java/nl/talsmasoftware/reflection/dto/AbstractDtoTest.java
@@ -18,11 +18,22 @@ package nl.talsmasoftware.reflection.dto;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.math.BigDecimal;
 
+import static nl.talsmasoftware.test.TestUtil.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  * Test DTO objects.
@@ -146,6 +157,17 @@ public class AbstractDtoTest {
         assertThat(valueObject, hasToString(equalTo("DtoRepresentationV1{number=42, name=\"Representation name\", " +
                 "amountInEuros=12.50, subObject=DtoRepresentationV1{number=12, " +
                 "subObject=DtoRepresentationV1{number=99}}}")));
+    }
+
+    @Test
+    public void testToStringTruncatesLongValues() {
+        String extremelyLongString = randomString(1024, 1024);
+        BigDecimal extremelyBigDecimal = new BigDecimal(randomString(1024, 1024, "0123456789"));
+        valueObject.name = extremelyLongString;
+        valueObject.amountInEuros = extremelyBigDecimal;
+        valueObject.subObject = null;
+        assertThat(valueObject, hasToString(equalTo(
+                "DtoRepresentationV1{number=42, name=<String>, amountInEuros=<BigDecimal>}")));
     }
 
     @Test

--- a/src/test/java/nl/talsmasoftware/reflection/strings/NonStringCharSequence.java
+++ b/src/test/java/nl/talsmasoftware/reflection/strings/NonStringCharSequence.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.reflection.strings;
+
+public class NonStringCharSequence implements CharSequence {
+    private final CharSequence delegate;
+
+    public NonStringCharSequence(CharSequence delegate) {
+        if (delegate == null) throw new NullPointerException("Delegate CharSequence is <null>");
+        this.delegate = delegate;
+    }
+
+    public int length() {
+        return delegate.length();
+    }
+
+    public char charAt(int index) {
+        return delegate.charAt(index);
+    }
+
+    public CharSequence subSequence(int start, int end) {
+        return delegate.subSequence(start, end);
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/src/test/java/nl/talsmasoftware/reflection/strings/ToStringBuilderTest.java
+++ b/src/test/java/nl/talsmasoftware/reflection/strings/ToStringBuilderTest.java
@@ -19,9 +19,15 @@ import nl.talsmasoftware.reflection.JavaBean;
 import nl.talsmasoftware.test.TestUtil;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+
 import static nl.talsmasoftware.test.TestUtil.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * @author Sjoerd Talsma
@@ -237,4 +243,38 @@ public class ToStringBuilderTest {
                         "value4=JavaBean{value1=\"a value\", value4=" + bean2ref + "}}}")));
     }
 
+    @Test
+    public void testMaximumPropertyLengthForCharSequence() {
+        CharSequence characters = new NonStringCharSequence("value");
+        assertThat(new ToStringBuilder(null).append(characters),
+                hasToString(equalTo("{\"value\"}")));
+
+        characters = new NonStringCharSequence(TestUtil.randomString(1024, 1024));
+        assertThat(new ToStringBuilder(null).append(characters),
+                hasToString(equalTo("{<NonStringCharSequence>}")));
+
+        characters = new NonStringCharSequence(TestUtil.randomString(1024, 1024)) {
+        };
+        assertThat(new ToStringBuilder(null).append("name", characters),
+                hasToString(equalTo("{name=<1024chars>}")));
+    }
+
+    @Test
+    public void testMaximumPropertyLengthForBigDecimal() {
+        BigDecimal decimal = new BigDecimal("1234.56");
+        assertThat(new ToStringBuilder(null).append(decimal), hasToString(equalTo("{1234.56}")));
+
+        decimal = new BigDecimal(TestUtil.randomString(1024, 1024, "0123456789"));
+        assertThat(new ToStringBuilder(null).append(decimal), hasToString(equalTo("{<BigDecimal>}")));
+    }
+
+    @Test
+    public void testEscapedStringQuotes() {
+        char backslash = '\\', quote = '\"';
+        String testValue = "slash: [" + backslash + "], quote: [" + quote + "]";
+        String escaped = new ToStringBuilder(null).append(testValue).toString();
+        assertThat(escaped, equalTo(
+                "{\"slash: [" + backslash + backslash + "], " +
+                        "quote: [" + backslash + quote + "]\"}"));
+    }
 }


### PR DESCRIPTION
(when type is unavailable, show the number of characters instead of the
actual *huge* string)
